### PR TITLE
Avoid crash when input string to convert is empty

### DIFF
--- a/TenPrintCover/C64Converter.h
+++ b/TenPrintCover/C64Converter.h
@@ -9,6 +9,11 @@
 
 @interface C64Converter: NSObject
 
+/// Converts a string to a string that uses only the ASCII 64 letter set.
+///
+/// If the input string is empty, a random string will be returned.
+/// @param value The string to convert.
+/// @return A non-zero length string that employs only ASCII characters.
 + (nonnull NSString *)convert: (nullable NSString *)value;
 
 @end

--- a/TenPrintCover/C64Converter.m
+++ b/TenPrintCover/C64Converter.m
@@ -11,20 +11,25 @@
 
 @implementation C64Converter
 
-+ (NSString *)convert:(NSString *)value {
-    
++ (NSString *)convert:(NSString *)value
+{
     NSString *c64Letters = @" qQwWeErRtTyYuUiIoOpPaAsSdDfFgGhHjJkKlL:zZxXcCvVbBnNmM1234567890.";
-    
-    // returns a string with all the c64-letter available in the title or a random set if none
-    int i, len = (int)value.length;
+
+  if (value.length == 0) {
+    uint32_t index = arc4random_uniform((uint32_t)c64Letters.length);
+    unichar character = [c64Letters characterAtIndex:index];
+    value = [NSString stringWithCharacters:&character length:1];
+  }
+
+    NSUInteger len = value.length;
     NSMutableString *result = [NSMutableString stringWithCapacity:len];
     char letter;
-    for (i=0; i<len; i++) {
+    for (int i=0; i<len; i++) {
         letter = [value characterAtIndex:i];
         NSRange range = [self indexOf:letter inString:c64Letters];
         //        NSLog(@"letter: %c num: %d range: %d", letter, (int)letter, range.length);
         if (range.length == 0) {
-            int anIndex = (int)(letter%c64Letters.length);
+            int anIndex = (int)(letter % c64Letters.length);
             letter = [c64Letters characterAtIndex:anIndex];
         }
         [result appendString:[NSString stringWithFormat:@"%c", letter]];
@@ -37,14 +42,14 @@
     searchRange.location=(unsigned int)searchChar;
     searchRange.length=1;
     NSCharacterSet *set = [NSCharacterSet characterSetWithRange:searchRange];
-    
+
     // NSCharacterSet:characterSetWithRange by default is never supposed to
     // return nil. However, on iOS 14.5 beta, it is returning nil when the char
     // is non ASCII (e.g. accented character), causing the app to crash.
     if (set) {
         return [string rangeOfCharacterFromSet:set];
     }
-    
+
     // This is only triggered when passed a non ASCII character e.g. ñ, ó
     searchRange.location = NSNotFound;
     searchRange.length = 0;

--- a/TenPrintCover/C64Converter.m
+++ b/TenPrintCover/C64Converter.m
@@ -13,47 +13,47 @@
 
 + (NSString *)convert:(NSString *)value
 {
-    NSString *c64Letters = @" qQwWeErRtTyYuUiIoOpPaAsSdDfFgGhHjJkKlL:zZxXcCvVbBnNmM1234567890.";
-
+  NSString *c64Letters = @" qQwWeErRtTyYuUiIoOpPaAsSdDfFgGhHjJkKlL:zZxXcCvVbBnNmM1234567890.";
+  
   if (value.length == 0) {
     uint32_t index = arc4random_uniform((uint32_t)c64Letters.length);
     unichar character = [c64Letters characterAtIndex:index];
     value = [NSString stringWithCharacters:&character length:1];
   }
-
-    NSUInteger len = value.length;
-    NSMutableString *result = [NSMutableString stringWithCapacity:len];
-    char letter;
-    for (int i=0; i<len; i++) {
-        letter = [value characterAtIndex:i];
-        NSRange range = [self indexOf:letter inString:c64Letters];
-        //        NSLog(@"letter: %c num: %d range: %d", letter, (int)letter, range.length);
-        if (range.length == 0) {
-            int anIndex = (int)(letter % c64Letters.length);
-            letter = [c64Letters characterAtIndex:anIndex];
-        }
-        [result appendString:[NSString stringWithFormat:@"%c", letter]];
+  
+  NSUInteger len = value.length;
+  NSMutableString *result = [NSMutableString stringWithCapacity:len];
+  char letter;
+  for (int i=0; i<len; i++) {
+    letter = [value characterAtIndex:i];
+    NSRange range = [self indexOf:letter inString:c64Letters];
+    //        NSLog(@"letter: %c num: %d range: %d", letter, (int)letter, range.length);
+    if (range.length == 0) {
+      int anIndex = (int)(letter % c64Letters.length);
+      letter = [c64Letters characterAtIndex:anIndex];
     }
-    return [NSString stringWithString:result];
+    [result appendString:[NSString stringWithFormat:@"%c", letter]];
+  }
+  return [NSString stringWithString:result];
 }
 
 + (NSRange) indexOf:(char) searchChar inString:(NSString *)string {
-    NSRange searchRange;
-    searchRange.location=(unsigned int)searchChar;
-    searchRange.length=1;
-    NSCharacterSet *set = [NSCharacterSet characterSetWithRange:searchRange];
-
-    // NSCharacterSet:characterSetWithRange by default is never supposed to
-    // return nil. However, on iOS 14.5 beta, it is returning nil when the char
-    // is non ASCII (e.g. accented character), causing the app to crash.
-    if (set) {
-        return [string rangeOfCharacterFromSet:set];
-    }
-
-    // This is only triggered when passed a non ASCII character e.g. ñ, ó
-    searchRange.location = NSNotFound;
-    searchRange.length = 0;
-    return searchRange;
+  NSRange searchRange;
+  searchRange.location=(unsigned int)searchChar;
+  searchRange.length=1;
+  NSCharacterSet *set = [NSCharacterSet characterSetWithRange:searchRange];
+  
+  // NSCharacterSet:characterSetWithRange by default is never supposed to
+  // return nil. However, on iOS 14.5 beta, it is returning nil when the char
+  // is non ASCII (e.g. accented character), causing the app to crash.
+  if (set) {
+    return [string rangeOfCharacterFromSet:set];
+  }
+  
+  // This is only triggered when passed a non ASCII character e.g. ñ, ó
+  searchRange.location = NSNotFound;
+  searchRange.length = 0;
+  return searchRange;
 }
 
 @end

--- a/TenPrintCover/NYPLTenPrintCoverView.m
+++ b/TenPrintCover/NYPLTenPrintCoverView.m
@@ -195,7 +195,8 @@ float ofMap(float value, float inputMin, float inputMax, float outputMin, float 
 	shapeThickness = baseThickness * self.viewScale;
 	for (i=0; i<gridCount; i++) {
 		for (j=0; j<gridCount; j++) {
-			char character = [c64Title characterAtIndex:(item%c64Title.length)];
+      // c64Title is guaranteed to have length > 0, so the modulus here is safe
+			char character = [c64Title characterAtIndex:(item % c64Title.length)];
 			[self drawShape:character xPos:offset+artworkStartX+(j*gridSize) yPos:offset+artworkStartY+(i*gridSize) size:gridSize];
 			item++;
 		}

--- a/TenPrintCoverTests/C64ConversionTests.swift
+++ b/TenPrintCoverTests/C64ConversionTests.swift
@@ -38,7 +38,7 @@ class C64ConversionTests: XCTestCase {
     for i in 0..<books.count {
       let stringToConvert = books[i]
       let expected = converted[i]
-        let result = C64Converter.convert(stringToConvert)
+      let result = C64Converter.convert(stringToConvert)
       XCTAssertEqual(expected, result)
     }
   }
@@ -74,5 +74,9 @@ class C64ConversionTests: XCTestCase {
     XCTAssertEqual(expected, result)
   }
 
+  func testC64ConversionForEmptyString() {
+    let result = C64Converter.convert("")
+    XCTAssertGreaterThan(result.count, 0)
+  }
 }
 


### PR DESCRIPTION
There was an edge case that lead to a crash, when the input string fed to the C64 conversion is empty. In that case the modulus computation would receive a 0 divisor, which of course will crash the app. This provides a quick fix by just returning a random 1-character string in that case. 